### PR TITLE
Patch for authenticated bind search

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ Most of the configuration should be completed during the installation; However i
 * `$basedn` would be your LDAP server's search base distinguished name. This would be where Codiad looks for user entries within LDAP. Example:
  * `$basedn = 'ou=people,dc=example,dc=com';`
 
+* Set `$anonbind` based on whether or not your LDAP server uses anonymous binds for search. Active Directory does not allow this by default, however this is the default method for most servers based on the LDAP standard. Optionally one can bind to a user for search on any LDAP server or enable anonymous binds for search on Active Directory, however this allows for any search option. Examples:
+ * `$anonbind = true;`
+ * `$anonbind = false;`
+
+* `$binddn` and `$bindpass` are the corresponding DN and password to bind to for search if `$anonbind` is disabled. Examples:
+ * `$binddn = "cn=binduser,cn=Users,dc=example,dc=com";`
+ * `$bindpass = "secret";`
+
 * `$filter` is your LDAP user search filter. This tells Codiad which attribute/value pairs to look for as the username to look up. If you aren't sure what to do here, you may use one of the alternatives or use the references either at http://tools.ietf.org/search/rfc4515 (quite technical IETF RFC) or http://goo.gl/FOdGp7 (CentOS documentation page on LDAP search filters). The variable `$1` must always be supplied as a value as it signifies the username. The default will allow a CN or an email to log in; however, the user environments between the CN and email logins would differ, essentially acting as separate users within Codiad. Examples:
  * `$filter = '(&(objectClass=*)(|(cn=$1)(email=$1)))';` <-- Allows CN or email to denote the username. As it uses a logical `or` (`|`), it allows more than one field to directly act as the username, in effect allowing each LDAP user (with both a CN and an email attribute) to create/log-in to two Codiad users if they so desire.
 

--- a/ldap.php
+++ b/ldap.php
@@ -106,9 +106,9 @@
 	    
 	    // Pre-authenticate based on whether or not we are using anonymous bind
 	    if ( $anonbind == true ) {
-	    	$preauth = $socket;
+		$preauth = $socket;
 	    } else {
-                $preauth = ldap_bind( $socket, $binddn, $bindpass );
+		$preauth = ldap_bind( $socket, $binddn, $bindpass );
 	    }
 
 	    // Check if LDAP socket creation was a success.

--- a/ldap.php
+++ b/ldap.php
@@ -104,14 +104,20 @@
 	    ldap_set_option( $socket, LDAP_OPT_PROTOCOL_VERSION, $version );
 	    ldap_set_option( $socket, LDAP_OPT_REFERRALS, 0 );
 	    
-	    // Pre-authenticate based on whether or not we are using anonymous bind
+	    // Check if we are using anonymous bind.
 	    if ( $anonbind == true ) {
+	    	
+	    	// Set preauth flag to value of socket on anonymous bind.
 		$preauth = $socket;
+		
 	    } else {
+	    	
+	    	// Set preauth flag using call to ldap_bind on authenticated bind.
 		$preauth = ldap_bind( $socket, $binddn, $bindpass );
+		
 	    }
 
-	    // Check if LDAP socket creation was a success.
+	    // Check if LDAP pre-authentication (or socket creation) was a success.
 	    if ( $preauth == true ) {
 
 		// Search through basedn based on the filter, and count entries.

--- a/ldap.php
+++ b/ldap.php
@@ -36,11 +36,14 @@
     $basedn = "ou=people,dc=example,dc=com";
     
 // Use anonymous bind
-//  Does not work on Active Directory, however this is the default
-//  method for OpenLDAP.
+//  This does not work by default on Active Directory, however this is the 
+//  default method for most servers based on the LDAP standard.
+//    Optionally one can bind to a user for search on any LDAP server or
+//    enable anonymous binds for search on Active Directory, however this
+//    allows for any search option.
     $anonbind = true;
     
-// LDAP User for Bind (if anonymous bind is set to "false")
+// LDAP User for bind (if anonymous bind is set to "false")
     $binddn = "cn=binduser,cn=Users,dc=example,dc=com";
     $bindpass = "";
 
@@ -101,14 +104,14 @@
 	    ldap_set_option( $socket, LDAP_OPT_PROTOCOL_VERSION, $version );
 	    ldap_set_option( $socket, LDAP_OPT_REFERRALS, 0 );
 	    
-	    // System user bind to allow search
+	    // Pre-authenticate based on whether or not we are using anonymous bind
 	    if ( $anonbind == true ) {
-	    	$preauth = true;
+	    	$preauth = $socket;
 	    } else {
-                $preauth = ldap_bind( $socket, $binddn, $bindpass);
+                $preauth = ldap_bind( $socket, $binddn, $bindpass );
 	    }
 
-	    // Check if LDAP socket creation was a success
+	    // Check if LDAP socket creation was a success.
 	    if ( $preauth == true ) {
 
 		// Search through basedn based on the filter, and count entries.

--- a/ldap.php
+++ b/ldap.php
@@ -43,7 +43,7 @@
 //    allows for any search option.
     $anonbind = true;
     
-// LDAP User for bind (if anonymous bind is set to "false")
+// LDAP User for bind (if anonymous bind is set to "false").
     $binddn = "cn=binduser,cn=Users,dc=example,dc=com";
     $bindpass = "";
 

--- a/ldap.php
+++ b/ldap.php
@@ -35,8 +35,13 @@
 // The DN to search under on the server.
     $basedn = "ou=people,dc=example,dc=com";
     
-// Codiad System User for Bind
-    $binduserrdn = 'CN=codiadsys,CN=Users,DC=example,DC=com';
+// Use anonymous bind
+//  Does not work on Active Directory, however this is the default
+//  method for OpenLDAP.
+    $anonbind = true;
+    
+// LDAP User for Bind (if anonymous bind is set to "false")
+    $binddn = "cn=binduser,cn=Users,dc=example,dc=com";
     $bindpass = "";
 
 // The LDAP search filter. If you aren't sure what this is, the official
@@ -97,7 +102,11 @@
 	    ldap_set_option( $socket, LDAP_OPT_REFERRALS, 0 );
 	    
 	    // System user bind to allow search
-            $preauth = ldap_bind( $socket, $binduserrdn, $bindpass);
+	    if ( $anonbind == true ) {
+	    	$preauth = true;
+	    } else {
+                $preauth = ldap_bind( $socket, $binddn, $bindpass);
+	    }
 
 	    // Check if LDAP socket creation was a success
 	    if ( $preauth == true ) {

--- a/ldap.php
+++ b/ldap.php
@@ -34,6 +34,10 @@
 
 // The DN to search under on the server.
     $basedn = "ou=people,dc=example,dc=com";
+    
+// Codiad System User for Bind
+    $binduserrdn = 'CN=codiadsys,CN=Users,DC=example,DC=com';
+    $bindpass = "";
 
 // The LDAP search filter. If you aren't sure what this is, the official
 // IETF RFC definition (quite technical) is here: 
@@ -91,9 +95,12 @@
 	    // Set initial LDAP values.
 	    ldap_set_option( $socket, LDAP_OPT_PROTOCOL_VERSION, $version );
 	    ldap_set_option( $socket, LDAP_OPT_REFERRALS, 0 );
+	    
+	    // System user bind to allow search
+            $preauth = ldap_bind( $socket, $binduserrdn, $bindpass);
 
 	    // Check if LDAP socket creation was a success
-	    if ( $socket == true ) {
+	    if ( $preauth == true ) {
 
 		// Search through basedn based on the filter, and count entries.
 		$result = ldap_search( $socket, $basedn, $tfilter );


### PR DESCRIPTION
Expand on smdion's patch for authenticated bind
- Added a config flag `$anonbind` and config variables `$binddn` and `$bindpass` to allow for authenticated bind for search.
- Added a `$preauth` flag to allow an authenticated bind for search and a conditional to set `$preauth` based on the value of `$anonbind`.
- Added call to `ldap_bind` in the case we are using an authenticated bind for search (`$anonbind` set to `false`).
- Update comments and README.md.
